### PR TITLE
プロジェクト一覧画面から更新メニューでキャンセルしても更新されるバグを修正し、プロジェクト一覧画面から招待ダイアログが開かないバグを修正し…

### DIFF
--- a/CharacomMaui.Presentation/Pages/ProjectListPage.xaml
+++ b/CharacomMaui.Presentation/Pages/ProjectListPage.xaml
@@ -55,7 +55,7 @@
             <DataTemplate>
               <components:ProjectInfoCard
                 EditRequested="OnEditRequested"
-                InviteRequested="OnInviteRequested"
+                InviteRequested="OnInviteRequestedAsync"
                 DeleteRequested="OnDeleteRequested"
                 ProjectFolderId="{Binding FolderId}"
                 CharaFolderId="{Binding CharaFolderId}"

--- a/CharacomMaui.Presentation/Pages/ProjectListPage.xaml.cs
+++ b/CharacomMaui.Presentation/Pages/ProjectListPage.xaml.cs
@@ -61,7 +61,10 @@ public partial class ProjectListPage : BasePage
       var projects = await _viewModel.GetProjectsAsync();
 
       if (projects == null)
+      {
+        await SnackBarService.Error("プロジェクト一覧の取得に失敗しました。");
         return;
+      }
 
       BindableLayout.SetItemsSource(ProjectsFlex, projects);
 
@@ -207,7 +210,7 @@ public partial class ProjectListPage : BasePage
       LogEditor.Text += $"招待します.{e.ProjectName}\n";
       var users = await _getUserInfoUseCase.GetUserListAsync(accessToken);
       var roles = await _projectRolesUseCase.ExecuteAsync(accessToken);
-      if (users == null || roles == null)
+      if (users == null || users.Count == 0 || roles == null)
       {
         await SnackBarService.Error("ユーザー一覧または権限一覧の取得に失敗しました。");
         return;

--- a/CharacomMaui.Presentation/Pages/ProjectListPage.xaml.cs
+++ b/CharacomMaui.Presentation/Pages/ProjectListPage.xaml.cs
@@ -76,25 +76,6 @@ public partial class ProjectListPage : BasePage
       System.Diagnostics.Debug.WriteLine($"OnAppearing Error: {ex}");
       await SnackBarService.Error("プロジェクト一覧の取得に失敗しました。");
     }
-    // var projects = await _viewModel.GetProjectsAsync();
-
-    // if (projects == null) return;
-    // try
-    // {
-    //   BindableLayout.SetItemsSource(ProjectsFlex, projects);
-    // }
-    // catch (Exception ex)
-    // {
-    //   Console.WriteLine(ex.Message);
-    //   await SnackBarService.Error("プロジェクト一覧の表示に失敗しました。");
-    //   return;
-    // }
-
-    // foreach (var project in projects)
-    // {
-    //   System.Console.WriteLine($"Project: {project.Name} (ID: {project.Id}) FolderId: {project.FolderId} CharaFolderId: {project.CharaFolderId}");
-    // }
-
   }
   protected override void OnDisappearing()
   {
@@ -226,6 +207,11 @@ public partial class ProjectListPage : BasePage
       LogEditor.Text += $"招待します.{e.ProjectName}\n";
       var users = await _getUserInfoUseCase.GetUserListAsync(accessToken);
       var roles = await _projectRolesUseCase.ExecuteAsync(accessToken);
+      if (users == null || roles == null)
+      {
+        await SnackBarService.Error("ユーザー一覧または権限一覧の取得に失敗しました。");
+        return;
+      }
       var dialog = new InviteUserDialog("ユーザーの招待", _dialogService, users, roles);
       await this.ShowPopupAsync(dialog);
       if (dialog.IsCanceled)

--- a/CharacomMaui.Presentation/Pages/ProjectListPage.xaml.cs
+++ b/CharacomMaui.Presentation/Pages/ProjectListPage.xaml.cs
@@ -25,6 +25,8 @@ public partial class ProjectListPage : BasePage
   private readonly AppStatusUseCase _appStatusUseCase;
   private readonly AppStatusNotifier _notifier;
   private readonly ISimpleProgressDialogService _simpleDialog;
+  private readonly IGetUserInfoUseCase _getUserInfoUseCase;
+  private readonly FetchProjectRolesUseCase _projectRolesUseCase;
   public ProjectListPage(IBoxFolderRepository repository,
   IDialogService dialogService,
   CreateProjectViewModel viewModel,
@@ -33,6 +35,8 @@ public partial class ProjectListPage : BasePage
   ISimpleProgressDialogService simpleDialog,
   IAppTokenStorageService tokenStorage,
   INotificationService notificationService,
+  IGetUserInfoUseCase getUserInfoUseCase,
+  FetchProjectRolesUseCase projectRolesUseCase,
   INotificationPanelService panelService) : base(notificationService, panelService, tokenStorage)
   {
     InitializeComponent();
@@ -41,6 +45,8 @@ public partial class ProjectListPage : BasePage
     _appStatusUseCase = appStatusUseCase;
     _viewModel = viewModel;
     _notifier = notifier;
+    _getUserInfoUseCase = getUserInfoUseCase;
+    _projectRolesUseCase = projectRolesUseCase;
     _simpleDialog = simpleDialog;
     _viewModel.SetUserStatus(_appStatusUseCase.GetAppStatus());
     System.Diagnostics.Debug.WriteLine($"status = {_viewModel._appStatus.ToString()}");
@@ -50,24 +56,44 @@ public partial class ProjectListPage : BasePage
   protected override async void OnAppearing()
   {
     base.OnAppearing();
-    var projects = await _viewModel.GetProjectsAsync();
-
-    if (projects == null) return;
     try
     {
+      var projects = await _viewModel.GetProjectsAsync();
+
+      if (projects == null)
+        return;
+
       BindableLayout.SetItemsSource(ProjectsFlex, projects);
+
+      foreach (var project in projects)
+      {
+        System.Console.WriteLine(
+            $"Project: {project.Name} (ID: {project.Id}) FolderId: {project.FolderId} CharaFolderId: {project.CharaFolderId}");
+      }
     }
     catch (Exception ex)
     {
-      Console.WriteLine(ex.Message);
-      await SnackBarService.Error("プロジェクト一覧の表示に失敗しました。");
-      return;
+      System.Diagnostics.Debug.WriteLine($"OnAppearing Error: {ex}");
+      await SnackBarService.Error("プロジェクト一覧の取得に失敗しました。");
     }
+    // var projects = await _viewModel.GetProjectsAsync();
 
-    foreach (var project in projects)
-    {
-      System.Console.WriteLine($"Project: {project.Name} (ID: {project.Id}) FolderId: {project.FolderId} CharaFolderId: {project.CharaFolderId}");
-    }
+    // if (projects == null) return;
+    // try
+    // {
+    //   BindableLayout.SetItemsSource(ProjectsFlex, projects);
+    // }
+    // catch (Exception ex)
+    // {
+    //   Console.WriteLine(ex.Message);
+    //   await SnackBarService.Error("プロジェクト一覧の表示に失敗しました。");
+    //   return;
+    // }
+
+    // foreach (var project in projects)
+    // {
+    //   System.Console.WriteLine($"Project: {project.Name} (ID: {project.Id}) FolderId: {project.FolderId} CharaFolderId: {project.CharaFolderId}");
+    // }
 
   }
   protected override void OnDisappearing()
@@ -99,7 +125,14 @@ public partial class ProjectListPage : BasePage
     var dialog = new CreateProjectDialog("プロジェクトの更新", topFolderItems, _dialogService, _viewModel, project);
     await this.ShowPopupAsync(dialog);
 
+
     // ダイアログから返ってきてから。。。
+    if (dialog.IsCanceled)
+    {
+      LogEditor.Text += "キャンセルされました";
+      return;
+    }
+
     if (dialog.SelectedTopFolder == null)
     {
       LogEditor.Text += "選択されていない";
@@ -178,13 +211,47 @@ public partial class ProjectListPage : BasePage
     }
 
   }
-
-  private void OnInviteRequested(object? sender, ProjectInfoEventArgs e)
+  private async void OnInviteRequestedAsync(object? sender, ProjectInfoEventArgs e)
   {
     LogEditor.Text += $"招待: {e.ProjectName} (ID: {e.ProjectId})\n";
 
-    // 例: 招待ダイアログ
-    // await Navigation.PushAsync(new InvitePage(e.ProjectId));
+    try
+    {
+      var accessToken = await _viewModel.GetAccessTokenAsync();
+      if (accessToken == string.Empty)
+      {
+        await SnackBarService.Error("アクセストークンが取得できませんでした。再ログインしてください。");
+        return;
+      }
+      LogEditor.Text += $"招待します.{e.ProjectName}\n";
+      var users = await _getUserInfoUseCase.GetUserListAsync(accessToken);
+      var roles = await _projectRolesUseCase.ExecuteAsync(accessToken);
+      var dialog = new InviteUserDialog("ユーザーの招待", _dialogService, users, roles);
+      await this.ShowPopupAsync(dialog);
+      if (dialog.IsCanceled)
+      {
+        LogEditor.Text += "キャンセルされました\n";
+        return;
+      }
+
+      var result = await _viewModel.InviteToProjectAsync(e.ProjectId, dialog.SelectedUserId, dialog.SelectedProjectRoleId);
+      if (result.Success)
+      {
+        LogEditor.Text += $"招待に成功しました。{dialog.SelectedUserId}, {dialog.SelectedProjectRoleId}\n";
+        await SnackBarService.Success("ユーザーをプロジェクトに招待しました。");
+      }
+      else
+      {
+        LogEditor.Text += $"招待に失敗しました: {result.Message}\n";
+        await SnackBarService.Error("ユーザーの招待に失敗しました。");
+      }
+    }
+    catch (Exception ex)
+    {
+      System.Diagnostics.Debug.WriteLine($"Invite error: {ex.Message}");
+      await SnackBarService.Error("ユーザーの招待中にエラーが発生しました。");
+    }
+
   }
 
   private async void OnCreateProjectBtn(object? sender, EventArgs e)
@@ -286,7 +353,6 @@ public partial class ProjectListPage : BasePage
   private async void OnSnackBarBtnClicked(object sender, EventArgs e)
   {
     Console.WriteLine("スナックバー押しました");
-    await DisplayAlert("Test", "Success", "OK");
     await SnackBarService.Info("ボタンを押しました。");
   }
   private void OnCardClicked(object sender, ProjectInfoEventArgs e)

--- a/CharacomMaui.Presentation/ViewModels/CreateProjectViewModel.cs
+++ b/CharacomMaui.Presentation/ViewModels/CreateProjectViewModel.cs
@@ -5,6 +5,7 @@ using CharacomMaui.Application.UseCases;
 using CharacomMaui.Domain.Entities;
 using CharacomMaui.Application.Interfaces;
 using CommunityToolkit.Maui.Converters;
+using Box.Sdk.Gen.Schemas;
 
 namespace CharacomMaui.Presentation.ViewModels;
 
@@ -15,11 +16,14 @@ public partial class CreateProjectViewModel : ObservableObject
   private readonly GetUserProjectsUseCase _getUserProjectsUseCase;
   private readonly UpdateStrokeMasterUseCase _updateStrokeMasterUseCase;
   private readonly UpdateStandardMasterUseCase _updateStandardMasterUseCase;
+  private readonly InviteToProjectUseCase _inviteToProjectUseCase;
   private readonly DeleteProjectUseCase _deleteProjectUseCase;
   private readonly IAppTokenStorageService _tokenStorage;
   private BoxItem _selectedFolder = new();
 
   public AppStatus _appStatus = new();
+  IAppLogger _logger;
+
   public BoxItem SelectedFolder
   {
     get => _selectedFolder;
@@ -42,6 +46,8 @@ public partial class CreateProjectViewModel : ObservableObject
                                 UpdateStrokeMasterUseCase updateStrokeMasterUseCase,
                                 UpdateStandardMasterUseCase updateStandardMasterUseCase,
                                 DeleteProjectUseCase deleteProjectUseCase,
+                                IAppLogger logger,
+                                InviteToProjectUseCase inviteToProjectUseCase,
                                 IAppTokenStorageService tokenStorage)
   {
     _getFolderItemsUsecase = getBoxFolderItemsUseCase;
@@ -50,6 +56,8 @@ public partial class CreateProjectViewModel : ObservableObject
     _updateStrokeMasterUseCase = updateStrokeMasterUseCase;
     _updateStandardMasterUseCase = updateStandardMasterUseCase;
     _deleteProjectUseCase = deleteProjectUseCase;
+    _inviteToProjectUseCase = inviteToProjectUseCase;
+    _logger = logger;
     _tokenStorage = tokenStorage;
   }
 
@@ -149,6 +157,39 @@ public partial class CreateProjectViewModel : ObservableObject
         Message = "AccessTokenの取得に失敗しました。"
       };
     return await _deleteProjectUseCase.ExecuteAsync(accessToken, projectId);
+  }
+  public async Task<string> GetAccessTokenAsync()
+  {
+    var tokens = await _tokenStorage.GetTokensAsync();
+    var accessToken = tokens?.AccessToken;
+    if (accessToken == null) return string.Empty;
+    return accessToken;
+  }
+  public async Task<SimpleApiResult> InviteToProjectAsync(string projectId, string toUserId, string toRoleId)
+  {
+    try
+    {
+      var tokens = await _tokenStorage.GetTokensAsync();
+      var accessToken = tokens?.AccessToken;
+      if (accessToken == null) return new SimpleApiResult(false, "accessTokenエラーが発生しました"); ;
+
+      var res = await _inviteToProjectUseCase.ExecuteAsync(accessToken, projectId, toUserId, toRoleId);
+      if (res.Success)
+      {
+        await _logger.SystemInfo(_appStatus.UserId, this.GetType().Name, "プロジェクトへ招待", "プロジェクトに招待しました。", new { projectId, toUserId, toRoleId });
+        return res;
+      }
+      else
+      {
+        await _logger.SystemWarning(_appStatus.UserId, this.GetType().Name, "プロジェクトへ招待", "プロジェクトへの招待に失敗しました。", new { projectId, toUserId, toRoleId });
+        return res;
+      }
+    }
+    catch (Exception ex)
+    {
+      await _logger.SystemError(ex, _appStatus.UserId, this.GetType().Name, "プロジェクトへ招待", new { projectId, toUserId, toRoleId });
+      return new SimpleApiResult(false, "想定外のエラーが発生しました");
+    }
   }
 }
 

--- a/CharacomMaui.Presentation/ViewModels/CreateProjectViewModel.cs
+++ b/CharacomMaui.Presentation/ViewModels/CreateProjectViewModel.cs
@@ -169,6 +169,12 @@ public partial class CreateProjectViewModel : ObservableObject
   {
     try
     {
+      if (string.IsNullOrWhiteSpace(projectId) ||
+        string.IsNullOrWhiteSpace(toUserId) ||
+        string.IsNullOrWhiteSpace(toRoleId))
+      {
+        return new SimpleApiResult(false, "招待パラメータが不正です");
+      }
       var tokens = await _tokenStorage.GetTokensAsync();
       var accessToken = tokens?.AccessToken;
       if (accessToken == null) return new SimpleApiResult(false, "accessTokenエラーが発生しました");

--- a/CharacomMaui.Presentation/ViewModels/CreateProjectViewModel.cs
+++ b/CharacomMaui.Presentation/ViewModels/CreateProjectViewModel.cs
@@ -22,7 +22,7 @@ public partial class CreateProjectViewModel : ObservableObject
   private BoxItem _selectedFolder = new();
 
   public AppStatus _appStatus = new();
-  IAppLogger _logger;
+  private readonly IAppLogger _logger;
 
   public BoxItem SelectedFolder
   {
@@ -171,7 +171,7 @@ public partial class CreateProjectViewModel : ObservableObject
     {
       var tokens = await _tokenStorage.GetTokensAsync();
       var accessToken = tokens?.AccessToken;
-      if (accessToken == null) return new SimpleApiResult(false, "accessTokenエラーが発生しました"); ;
+      if (accessToken == null) return new SimpleApiResult(false, "accessTokenエラーが発生しました");
 
       var res = await _inviteToProjectUseCase.ExecuteAsync(accessToken, projectId, toUserId, toRoleId);
       if (res.Success)


### PR DESCRIPTION
プロジェクト一覧画面から更新メニューで、キャンセルを押しても更新されるバグを修正。
プロジェクト一覧画面から招待メニューでダイアログが開かないバグを修正しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * プロジェクトへのユーザー招待を完全な非同期フローで実行できるようにしました
  * 招待時にユーザー情報とプロジェクトの役割を取得するフローを統合しました
* **改善**
  * 招待処理にアクセス トークン取得と外部呼び出しを組み込み、成功/失敗表示とログの扱いを強化しました
  * ダイアログのキャンセル時は早期終了するようにしました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->